### PR TITLE
Make as small as possible

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,8 @@
 
     "env": {
         "browser": true,
-        "node": true
+        "node": true,
+        "mocha": true
     },
 
     "rules": {
@@ -28,14 +29,14 @@
         "dot-notation": 2,
         "consistent-return": 2,
         "no-shadow": 2,
-        "no-undefined": 2,
+        "no-undef": 2,
         "no-multi-spaces": 2,
         "linebreak-style": 2,
 
         "react/display-name": 0, // babel covers this
         "react/jsx-boolean-value": 1,
         "react/jsx-no-undef": 1,
-        "react/jsx-quotes": 1,
+        "jsx-quotes": 1,
         "react/jsx-sort-prop-types": 0,
         "react/jsx-sort-props": 0,
         "react/jsx-uses-react": 1,
@@ -48,7 +49,7 @@
         "react/react-in-jsx-scope": 1,
         "react/self-closing-comp": 1,
         "react/sort-comp": 0,
-        "react/wrap-multilines": 1
+        "react/jsx-wrap-multilines": 1
     },
 
     "ecmaFeatures": {

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-sudo: false
 language: node_js
 node_js:
-  - 'iojs'
-  - '0.12'
-  - '0.11'
-  - '0.10'
+  - 6

--- a/package.json
+++ b/package.json
@@ -3,10 +3,21 @@
   "version": "0.2.2",
   "description": "Like lodash isEqual but for shallow equal",
   "main": "modules/index.js",
+  "jsnext:main": "src/index.js",
   "scripts": {
-    "test": "mocha --compilers js:babel/register",
-    "build": "./scripts/build.sh",
-    "prepublish": "npm run build"
+    "build": "npm run rollup && npm run minify && npm run size",
+    "lint": "eslint src test",
+    "minify": "uglifyjs $npm_package_main --pure-funcs classCallCheck possibleConstructorReturn -c pure_getters -m -o $npm_package_main -p relative --in-source-map ${npm_package_main}.map --source-map ${npm_package_main}.map",
+    "prepublish": "npm run lint && npm run test && npm run build",
+    "rollup": "rollup -c -m -n $npm_package_name -o $npm_package_main",
+    "size": "echo \"Gzipped Size: $(strip-json-comments --no-whitespace $npm_package_main | gzip-size --raw)b\"",
+    "test": "mocha --compilers js:babel-register"
+  },
+  "babel": {
+    "presets": [
+      "es2015",
+      "stage-0"
+    ]
   },
   "author": {
     "name": "Alberto Leal",
@@ -26,12 +37,20 @@
     "compare"
   ],
   "devDependencies": {
-    "babel": "^5.8.21",
+    "babel-cli": "^6.24.0",
+    "babel-eslint": "^7.1.1",
+    "babel-preset-es2015": "^6.24.0",
+    "babel-preset-stage-0": "^6.22.0",
+    "babel-register": "^6.24.0",
     "chai": "^3.2.0",
-    "lodash": "^3.10.1",
-    "mocha": "^2.2.5"
-  },
-  "dependencies": {
-    "lodash.keys": "^3.1.2"
+    "eslint": "^3.17.1",
+    "eslint-plugin-react": "^6.10.0",
+    "gzip-size-cli": "^2.0.0",
+    "lodash": "^4.17.4",
+    "mocha": "^3.2.0",
+    "rollup": "^0.41.5",
+    "rollup-plugin-buble": "^0.15.0",
+    "strip-json-comments-cli": "^1.0.1",
+    "uglify-js": "^2.8.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "eslint": "^3.17.1",
     "eslint-plugin-react": "^6.10.0",
     "gzip-size-cli": "^2.0.0",
-    "lodash": "^4.17.4",
     "mocha": "^3.2.0",
     "rollup": "^0.41.5",
     "rollup-plugin-buble": "^0.15.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,10 @@
+import buble from 'rollup-plugin-buble';
+
+export default {
+    entry: 'src/index.js',
+    format: 'umd',
+    exports: 'default',
+    plugins: [
+        buble()
+    ]
+};

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-./node_modules/.bin/babel src --out-dir modules

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ export default function shallowEqual(objA, objB, compare, compareContext) {
     }
 
     for (let key in objA) {
+        if (!HOP.call(objA, key)) continue;
         if (!HOP.call(objB, key)) return false;
         let valueA = objA[key];
         let valueB = objB[key];
@@ -29,6 +30,7 @@ export default function shallowEqual(objA, objB, compare, compareContext) {
     }
 
     for (let key in objB) {
+        if (!HOP.call(objB, key)) continue;
         if (!HOP.call(objA, key)) return false;
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,10 @@
+const HOP = Object.prototype.hasOwnProperty;
 
-const fetchKeys = require('lodash.keys');
+export default function shallowEqual(objA, objB, compare, compareContext) {
 
-module.exports = function shallowEqual(objA, objB, compare, compareContext) {
+    let ret = compare ? compare.call(compareContext, objA, objB) : undefined;
 
-    const ret = compare ? compare.call(compareContext, objA, objB) : void 0;
-
-    if(ret !== void 0) {
+    if(ret !== undefined) {
         return !!ret;
     }
 
@@ -13,35 +12,24 @@ module.exports = function shallowEqual(objA, objB, compare, compareContext) {
         return true;
     }
 
-    if (typeof objA !== 'object' || objA === null ||
-        typeof objB !== 'object' || objB === null) {
+    if (typeof objA !== 'object' || !objA ||
+        typeof objB !== 'object' || !objB ) {
         return false;
     }
 
-    const keysA = fetchKeys(objA);
-    const keysB = fetchKeys(objB);
+    for (let key in objA) {
+        if (!HOP.call(objB, key)) return false;
+        let valueA = objA[key];
+        let valueB = objB[key];
 
-    const len = keysA.length;
-    if (len !== keysB.length) {
-        return false;
+        ret = compare ? compare.call(compareContext, valueA, valueB, key) : undefined;
+        if(ret === false || ret === undefined && valueA !== valueB) {
+            return false;
+        }
     }
 
-    compareContext = compareContext || null;
-
-    // Test for A's keys different from B.
-    const bHasOwnProperty = Object.prototype.hasOwnProperty.bind(objB);
-    for (let i = 0; i < len; i++) {
-        const key = keysA[i];
-        if (!bHasOwnProperty(key)) {
-            return false;
-        }
-        const valueA = objA[key];
-        const valueB = objB[key];
-
-        const ret = compare ? compare.call(compareContext, valueA, valueB, key) : void 0;
-        if(ret === false || ret === void 0 && valueA !== valueB) {
-            return false;
-        }
+    for (let key in objB) {
+        if (!HOP.call(objA, key)) return false;
     }
 
     return true;

--- a/test/shallowequal.spec.js
+++ b/test/shallowequal.spec.js
@@ -1,5 +1,4 @@
 import chai, { expect } from 'chai';
-import _ from 'lodash';
 import shallowequal from '../src';
 
 describe('shallowequal', function() {
@@ -124,7 +123,7 @@ describe('shallowequal', function() {
 
     it('should not handle comparisons if `customizer` returns `true`', () => {
         const customizer = function(value) {
-            return _.isString(value) || undefined;
+            return typeof value === 'string' || undefined;
         };
 
         expect(shallowequal('a', 'b', customizer)).to.equal(true);
@@ -134,7 +133,7 @@ describe('shallowequal', function() {
 
     it('should not handle comparisons if `customizer` returns `false`', () => {
         const customizer = function(value) {
-            return _.isString(value) ? false : undefined;
+            return typeof value === 'string' ? false : undefined;
         };
 
         expect(shallowequal('a', 'a', customizer)).to.equal(false);
@@ -143,15 +142,15 @@ describe('shallowequal', function() {
     });
 
     it('should return a boolean value even if `customizer` does not', () => {
-        let actual = shallowequal('a', 'b', _.constant('c'));
+        let actual = shallowequal('a', 'b', () => 'c');
         expect(actual).to.equal(true);
 
-        const values = _.without(falsey, undefined);
-        const expected = _.map(values, _.constant(false));
+        const values = falsey.filter(v => v !== undefined);
+        const expected = values.map(() => false);
 
         actual = [];
-        _.each(values, function(value) {
-            actual.push(shallowequal('a', 'a', _.constant(value)));
+        values.forEach(value => {
+            actual.push(shallowequal('a', 'a', () => (value)));
         });
 
         expect(actual).to.eql(expected);

--- a/test/shallowequal.spec.js
+++ b/test/shallowequal.spec.js
@@ -1,15 +1,10 @@
-const chai = require('chai');
-const expect = chai.expect;
-const _ = require('lodash');
+import chai, { expect } from 'chai';
+import _ from 'lodash';
+import shallowequal from '../src';
 
 describe('shallowequal', function() {
 
-    let shallowequal;
     const falsey = [, '', 0, false, NaN, null, undefined];
-
-    beforeEach(() => {
-        shallowequal = require('../src');
-    });
 
     // test cases copied from https://github.com/facebook/fbjs/blob/82247de1c33e6f02a199778203643eaee16ea4dc/src/core/__tests__/shallowEqual-test.js
     it('returns false if either argument is null', () => {
@@ -68,6 +63,16 @@ describe('shallowequal', function() {
         ).to.equal(false);
     });
 
+    it('returns true is values are not primitives but are ===', () => {
+        let obj = {};
+        expect(
+          shallowequal(
+            {a: 1, b: 2, c: obj},
+            {a: 1, b: 2, c: obj}
+          )
+        ).to.equal(true);
+    });
+
     // subsequent test cases are copied from lodash tests
     it('returns false if arguments are not shallow equal', () => {
         expect(
@@ -101,11 +106,11 @@ describe('shallowequal', function() {
     });
 
     it('should set the `this` binding', () => {
-      const actual = shallowequal('a', 'b', function(a, b) {
-        return this[a] == this[b];
-      }, { 'a': 1, 'b': 1 });
+        const actual = shallowequal('a', 'b', function(a, b) {
+            return this[a] == this[b];
+        }, { 'a': 1, 'b': 1 });
 
-      expect(actual).to.equal(true);
+        expect(actual).to.equal(true);
     });
 
     it('should handle comparisons if `customizer` returns `undefined`', () => {


### PR DESCRIPTION
Was looking to use this in my project and saw that it could be smaller.  I did a few things to accomplish that:

1. Remove the prod dependency on lodash.keys.  lodash.keys loops over the objects and does a hasOwnPropertyCheck.  Since you are already doing that in the later loops, for objects that are equal you end up looping over them 4 times.  By removing that call and the subsequent length check, and adding a loop over the second object, you end up with the same amount of calls to hasOwnProperty and the same number of effective loops, while eliminating the need to bring in lodash.keys.  except for extraordinarily large objects that happen to have a different number of keys, you don't lose any performance by dropping the length check.  I thought the size decrease for all users was more important than the slight performance gain for some scenarios
2. used rollup and uglify to get the gzip'd final size down to 329 bytes, which still exporting a umd bundle useful for old and new javascript projects
3. Got rid of the dev dependency on lodash by simply replacing the lodash methods with modern ES6 equivalent methods
4. updated eslint rules to fix deprecation warnings
5. Fixed the list of dev dependencies so that the project works out of the box after doing npm install

This makes for a tidy shallow equal that is useful for folks that want to (or not) use it with lodash