### PR TITLE
Clarify behavior when keys are different

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 
 Performs a **_shallow equality_** comparison between two values (i.e. `value` and `other`) to determine if they are equivalent.
 
-The equality is performed by iterating through keys on the given `value`, and returning `false` whenever any key has values which are not **strictly equal** between `value` and `other`. Otherwise, return `true` whenever the values of all keys are strictly equal.
+The equality check returns true if `value` and `other` are already strictly equal, OR when all the following are true:
+  - `value` and `other` are both objects with the same keys
+  - For each key, the value in `value` and `other` are **strictly equal** (`===`)
 
 If `customizer` (expected to be a function) is provided it is invoked to compare values. If `customizer` returns `undefined` (i.e. `void 0`), then comparisons are handled by the `shallowequal` function instead.
 


### PR DESCRIPTION
When reading the README, this paragraph

> The equality is performed by iterating through keys on the given `value`, and returning `false` whenever any key has values which are not **strictly equal** between `value` and `other`. Otherwise, return `true` whenever the values of all keys are strictly equal.

suggests that extraneous keys in `other` (that aren't present in `value`) don't matter for the equality check.  In particular, "the equality is performed by iterating through keys on the given `value`" is what gives this impression. 

In other words, one might erroneously think, after reading the README description, that calling `shallowEqual({a: 5}, {a: 5, b: 6})` would return `true`, since when you iterate through the keys of `{a: 5}`, every key (just `'a'`) has a value that's strictly equal between the two comparands (`5`). However, this isn't actually the case, since there's a [keys length check](https://github.com/dashed/shallowequal/blob/master/index.js#L21) 

I was unsure about this behavior until I read the source -- hopefully this clarifies it for other people who might misinterpret this!

Thanks for putting together this library!