### PR TITLE
Account for `NaN === NaN` evaluating to `false`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,11 @@
 //
 
+function defaultCompare(a, b) {
+  // `NaN === NaN` returns `false`
+  // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN#Polyfill
+  return a === b || (typeof a === 'number' && a !== a && typeof b === 'number' && b !== b);
+}
+
 module.exports = function shallowEqual(objA, objB, compare, compareContext) {
   var ret = compare ? compare.call(compareContext, objA, objB) : void 0;
 
@@ -7,7 +13,7 @@ module.exports = function shallowEqual(objA, objB, compare, compareContext) {
     return !!ret;
   }
 
-  if (objA === objB) {
+  if (defaultCompare(objA, objB)) {
     return true;
   }
 
@@ -37,7 +43,7 @@ module.exports = function shallowEqual(objA, objB, compare, compareContext) {
 
     ret = compare ? compare.call(compareContext, valueA, valueB, key) : void 0;
 
-    if (ret === false || (ret === void 0 && valueA !== valueB)) {
+    if (ret === false || (ret === void 0 && !defaultCompare(valueA, valueB))) {
       return false;
     }
   }

--- a/index.js
+++ b/index.js
@@ -1,11 +1,5 @@
 //
 
-function defaultCompare(a, b) {
-  // `NaN === NaN` returns `false`
-  // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN#Polyfill
-  return a === b || (typeof a === 'number' && a !== a && typeof b === 'number' && b !== b);
-}
-
 module.exports = function shallowEqual(objA, objB, compare, compareContext) {
   var ret = compare ? compare.call(compareContext, objA, objB) : void 0;
 
@@ -13,7 +7,7 @@ module.exports = function shallowEqual(objA, objB, compare, compareContext) {
     return !!ret;
   }
 
-  if (defaultCompare(objA, objB)) {
+  if (Object.is(objA, objB)) {
     return true;
   }
 
@@ -43,7 +37,7 @@ module.exports = function shallowEqual(objA, objB, compare, compareContext) {
 
     ret = compare ? compare.call(compareContext, valueA, valueB, key) : void 0;
 
-    if (ret === false || (ret === void 0 && !defaultCompare(valueA, valueB))) {
+    if (ret === false || (ret === void 0 && !Object.is(valueA, valueB))) {
       return false;
     }
   }


### PR DESCRIPTION
A spurious key `foo: NaN` would otherwise forever result in `shallowEqual(objA, objA)` returning `false`